### PR TITLE
Update debian.rb

### DIFF
--- a/recipes/debian.rb
+++ b/recipes/debian.rb
@@ -47,3 +47,9 @@ dpkg_package 'statsd' do
   source "#{node['statsd']['tmp_dir']}/statsd_#{node['statsd']['package_version']}_all.deb"
   options '--force-confold'
 end
+
+# We do our config in /etc/statsd/config.js, this isn't needed.
+file '/etc/statsd/localConfig.js' do
+  action :delete
+  notifies :restart, "service[statsd]", :delayed
+end


### PR DESCRIPTION
This file gets loaded after config.js and has all the default values, which makes it impossible to override node['statsd']['graphite_host'].

I ran into this on Ubuntu 14.04, but if it's happening elsewhere you might want to put the deletion in the default recipe.